### PR TITLE
added First Setup section to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,5 +9,40 @@ Please find more info about each part in the relevant Readme file ([frontend](fr
 When implementing a new feature or fixing a bug, please create a new pull request against `main` from a feature/bug branch and add `@vanessa-cooper` as reviewer.
 
 ## First setup
+### Clone Repository
+Clone the repository to your machine:
+```
+git clone https://github.com/ObelusFamily/Anythink-Market-gx6yo.git
+```
 
-**[TODO 05/01/2018 @vanessa-cooper]:** _It's been a while since anyone ran a fresh copy of this repo. I think it's worth documenting the steps needed to install and run the repo on a new machine?_
+### Install Docker
+In order to run the project, it's necessary to install docker.
+Use the following link to install it on Linux, MacOS and Windows:
+```
+https://docs.docker.com/get-docker/
+```
+### Verify Docker
+Verify docker is installed using the following commands in your terminal:
+```
+docker -v
+```
+and
+```
+docker-compose -v
+```
+### Run Project
+From the project root directory run:
+```
+docker-compose up
+```
+Test if the project backend is running by opening:
+```
+http://localhost:3000/api/ping
+```
+To verify the frontend open:
+```
+http://localhost:3001/register
+```
+If everything is working correctly, you should be able to create a new user.
+
+


### PR DESCRIPTION
I've written out the First Setup section of the readme so users can have the steps necessary to setup and run the project on a new machine.

This closes the following TODO:
[TODO 05/01/2018 @vanessa-cooper]: It's been a while since anyone ran a fresh copy of this repo. I think it's worth documenting the steps needed to install and run the repo on a new machine?